### PR TITLE
hanami から自動で rakee task を load できるようにする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,3 @@ begin
   task default: :spec
 rescue LoadError
 end
-
-Dir[File.expand_path('../tasks', __FILE__) << '/*.rake'].each { |file| load file }

--- a/rakelib/clear_users.rake
+++ b/rakelib/clear_users.rake
@@ -1,0 +1,6 @@
+namespace :reset do
+  desc "Clear users"
+  task clear_users: :environment do
+    UserRepository.new.clear
+  end
+end

--- a/tasks/clear_users.rake
+++ b/tasks/clear_users.rake
@@ -1,4 +1,0 @@
-desc "Clear users"
-task clear_users: :environment do
-  UserRepository.new.clear
-end


### PR DESCRIPTION
#8 の fix

* Rakefile に task がある folder を load する形ではなく
* /rakelib フォルダーを生成し、hanami  から自動で task を load するように変更  